### PR TITLE
Configuración de archivo gitignore y nuevos archivos de solución

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/Debug/Aviso_Evento_Log.html
+*.exe
+bin/*
+obj/*
+Picking.suo

--- a/Picking.csproj
+++ b/Picking.csproj
@@ -18,10 +18,14 @@
     <NativePlatformName>Windows CE</NativePlatformName>
     <FormFactorID>
     </FormFactorID>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <ApplicationIcon>adn_picking.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -52,8 +56,14 @@
   <ItemGroup>
     <Reference Include="Microsoft.WindowsCE.Forms" />
     <Reference Include="mscorlib" />
-    <Reference Include="Symbol, Version=2.8.0.0, Culture=neutral, PublicKeyToken=68ec8db391f150ca, processorArchitecture=MSIL" />
-    <Reference Include="Symbol.Barcode, Version=2.9.0.0, Culture=neutral, PublicKeyToken=68ec8db391f150ca, processorArchitecture=MSIL" />
+    <Reference Include="Symbol, Version=2.8.0.0, Culture=neutral, PublicKeyToken=68ec8db391f150ca, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>O:\Aplicaciones\Desarrollo\ADN\Librerias Motorola Symbol\Symbol.dll</HintPath>
+    </Reference>
+    <Reference Include="Symbol.Barcode, Version=2.9.0.0, Culture=neutral, PublicKeyToken=68ec8db391f150ca, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>O:\Aplicaciones\Desarrollo\ADN\Librerias Motorola Symbol\Symbol.Barcode.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlClient, Version=3.0.3600.0, Culture=neutral, PublicKeyToken=3be235df1c8d2ad3, processorArchitecture=MSIL" />

--- a/Picking.csproj.user
+++ b/Picking.csproj.user
@@ -1,0 +1,5 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DeployDeviceID>E282E6BE-C7C3-4ece-916A-88FB1CF8AF3C</DeployDeviceID>
+  </PropertyGroup>
+</Project>

--- a/Picking.sln
+++ b/Picking.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 10.00
+# Visual Studio 2008
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picking", "Picking.csproj", "{D0C3BDA2-2CD9-422F-83B8-F6676931282E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D0C3BDA2-2CD9-422F-83B8-F6676931282E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0C3BDA2-2CD9-422F-83B8-F6676931282E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0C3BDA2-2CD9-422F-83B8-F6676931282E}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{D0C3BDA2-2CD9-422F-83B8-F6676931282E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0C3BDA2-2CD9-422F-83B8-F6676931282E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0C3BDA2-2CD9-422F-83B8-F6676931282E}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Se realiza la configuración correspondiente para el archivo gitignore,
excluyendo las carpetas bin y obj, también se guarda los nuevos archivos
que hacen referencia a la solución Picking